### PR TITLE
fixing VueAuthenticatePlugin type

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -61,7 +61,9 @@ export declare class VueAuthenticate {
   ): Promise<{}>;
 }
 
-export const VueAuthenticatePlugin: (app: App, options?: AuthenticateOptions) => void;
+declare namespace VueAuthenticatePlugin {
+  function install(app: App, options?: AuthenticateOptions): void;
+}
 
 export interface AuthenticateOptions {
   baseUrl?: string;


### PR DESCRIPTION
It seems to me the that `VueAuthenticatePlugin  `does not have a correct typing in declaration file, 
it is an object with an install function.
